### PR TITLE
feat: hyper feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,11 +60,14 @@ dependencies = [
  "crossbeam-queue",
  "futures-core",
  "http-body",
+ "http-body-util",
+ "hyper",
  "lol_html",
  "pin-project-lite",
  "tokio",
  "tokio-stream",
  "tokio-test",
+ "tokio-util",
 ]
 
 [[package]]
@@ -501,6 +504,31 @@ checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "hyper"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
+dependencies = [
+ "bytes",
+ "http",
+ "http-body",
+ "tokio",
 ]
 
 [[package]]
@@ -1102,6 +1130,19 @@ dependencies = [
  "futures-core",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,11 +14,16 @@ atomic-waker = "1.1"
 bytes = "1.7"
 crossbeam-queue = "0.3"
 futures-core = "0.3"
-http-body = "1.0"
 lol_html = "1.2"
 pin-project-lite = "0.2"
 tokio = { version = "1.40" }
 tokio-stream = "0.1"
+
+# Optional Dependencies
+http-body = { version = "1.0", optional = true }
+http-body-util = { version = "0.1", optional = true }
+hyper = { version = "1.4", optional = true }
+tokio-util = { version = "0.7", features = ["io"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["async", "async_tokio"] }
@@ -27,6 +32,7 @@ tokio-test = "0.4"
 
 [features]
 bench = ["tokio/rt-multi-thread"]
+hyper = ["dep:http-body", "dep:http-body-util", "dep:hyper", "dep:tokio-util"]
 
 [[bench]]
 name = "bench_main"

--- a/benches/benchmarks/throughput.rs
+++ b/benches/benchmarks/throughput.rs
@@ -12,9 +12,9 @@ use tokio_test::io::Mock;
 async fn rewrite(source: Mock, settings: Settings<'static, 'static>) {
     let local_set = task::LocalSet::new();
     local_set.run_until(async move {
-        let rwr = Rewriter::new(source, settings);
-        let mut stream = rwr.output_reader();
-        let rewriter_handle = task::spawn_local(rwr);
+        let rewriter = Rewriter::new(source, settings);
+        let mut stream = rewriter.output_reader();
+        let rewriter_handle = task::spawn_local(rewriter);
         let mut buf = String::new();
         stream.read_to_string(&mut buf).await.unwrap();
         let _ = rewriter_handle.await.unwrap();

--- a/benches/benchmarks/throughput.rs
+++ b/benches/benchmarks/throughput.rs
@@ -13,7 +13,7 @@ async fn rewrite(source: Mock, settings: Settings<'static, 'static>) {
     let local_set = task::LocalSet::new();
     local_set.run_until(async move {
         let rwr = Rewriter::new(source, settings);
-        let mut stream = rwr.output_stream();
+        let mut stream = rwr.output_reader();
         let rewriter_handle = task::spawn_local(rwr);
         let mut buf = String::new();
         stream.read_to_string(&mut buf).await.unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,11 @@
 #![deny(clippy::expect_used)]
 #![deny(clippy::missing_assert_message)]
 
-pub mod sink;
-pub mod stream;
+pub mod reader;
 pub mod rewriter;
 pub mod settings;
+pub mod sink;
+pub mod stream;
 
 use bytes::Bytes;
 use crossbeam_queue::SegQueue;

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,0 +1,72 @@
+use crate::ByteQueue;
+use atomic_waker::AtomicWaker;
+use std::io;
+use std::io::ErrorKind;
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use tokio::io::{AsyncRead, ReadBuf};
+
+pub struct ByteReader {
+    queue: Arc<ByteQueue>,
+    waker: Arc<AtomicWaker>,
+    done: Arc<AtomicBool>,
+}
+
+impl ByteReader {
+    pub fn new(queue: Arc<ByteQueue>, waker: Arc<AtomicWaker>, done: Arc<AtomicBool>) -> Self {
+        Self { queue, waker, done }
+    }
+}
+
+impl AsyncRead for ByteReader {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        if !self.queue.is_empty() {
+            if let Some(bytes) = self.queue.pop() {
+                buf.put_slice(&bytes);
+                Poll::Ready(Ok(()))
+            } else {
+                let err = io::Error::new(ErrorKind::Other, "data queue is empty");
+                Poll::Ready(Err(err))
+            }
+        } else if self.done.load(Ordering::SeqCst) {
+            Poll::Ready(Ok(()))
+        } else {
+            self.waker.register(cx.waker());
+            Poll::Pending
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bytes::Bytes;
+    use tokio::io::AsyncReadExt;
+
+    #[tokio::test]
+    async fn async_read_impl() {
+        let input = "ABC";
+
+        let queue = ByteQueue::new();
+        queue.push(Bytes::from(input));
+
+        let mut reader = ByteReader::new(
+            Arc::new(queue),
+            Arc::new(AtomicWaker::new()),
+            Arc::new(AtomicBool::new(true)),
+        );
+
+        let mut output = String::new();
+        let bytes_read = reader.read_to_string(&mut output).await;
+
+        assert!(bytes_read.is_ok());
+        assert_eq!(bytes_read.unwrap(), output.len());
+        assert_eq!(output, input);
+    }
+}

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -128,9 +128,9 @@ mod tests {
         })];
         settings.buffer_size = 1024;
 
-        let writer = Rewriter::new(source, settings);
-        let mut reader = writer.output_reader();
-        writer.await.unwrap();
+        let rewriter = Rewriter::new(source, settings);
+        let mut reader = rewriter.output_reader();
+        rewriter.await.unwrap();
 
         let mut output = String::new();
         let bytes_read = reader.read_to_string(&mut output).await;

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -1,5 +1,7 @@
+use crate::reader::ByteReader;
 use crate::settings::Settings;
 use crate::sink::RelaySink;
+#[cfg(feature = "hyper")]
 use crate::stream::ByteStream;
 use crate::ByteQueue;
 use atomic_waker::AtomicWaker;
@@ -52,6 +54,11 @@ where
         }
     }
 
+    pub fn output_reader(&self) -> ByteReader {
+        ByteReader::new(self.queue.clone(), self.waker.clone(), self.done.clone())
+    }
+
+    #[cfg(feature = "hyper")]
     pub fn output_stream(&self) -> ByteStream {
         ByteStream::new(self.queue.clone(), self.waker.clone(), self.done.clone())
     }
@@ -105,7 +112,7 @@ mod tests {
     use crate::settings::Settings;
     use lol_html::element;
     use lol_html::html_content::ContentType;
-    use tokio_stream::StreamExt;
+    use tokio::io::AsyncReadExt;
 
     #[tokio::test]
     async fn rewrite_html() {
@@ -122,22 +129,14 @@ mod tests {
         settings.buffer_size = 1024;
 
         let writer = Rewriter::new(source, settings);
-        let stream = writer.output_stream();
+        let mut reader = writer.output_reader();
         writer.await.unwrap();
 
-        let output: Vec<String> = stream
-            .map(|frame| frame
-                .expect("Expected stream to contain valid frames")
-                .into_data()
-                .expect("Expected frames to hold valid data")
-            )
-            .map(|bytes|
-                std::str::from_utf8(&bytes)
-                    .expect("Expected frame data to be valid utf8")
-                    .to_string()
-            )
-            .collect().await;
+        let mut output = String::new();
+        let bytes_read = reader.read_to_string(&mut output).await;
 
-        assert_eq!(output.join(""), expected);
+        assert!(bytes_read.is_ok());
+        assert_eq!(bytes_read.unwrap(), output.len());
+        assert_eq!(output, expected);
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -21,12 +21,13 @@ async fn rewrite_html() {
     let local_set = task::LocalSet::new();
     let buffer = local_set.run_until(async move {
         let rewriter = Rewriter::new(source, settings);
-        let mut stream = rewriter.output_stream();
+        let mut stream = rewriter.output_reader();
 
         let rewriter_handle = task::spawn_local(rewriter);
 
         let mut buf = String::new();
         stream.read_to_string(&mut buf).await.unwrap();
+        
         let _ = rewriter_handle.await.unwrap();
         buf
     }).await;


### PR DESCRIPTION
Create the _hyper_ feature that allows to read the `Rewriter`'s output as a `ByteStream` - a type that implements `hyper::Body` and `futures_core::stream::Stream` for easier integration with hyper.