### PR TITLE
refactor(rewriter): push data into rewriter via stream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "hyper",
  "lol_html",
  "pin-project-lite",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ crossbeam-queue = "0.3"
 futures-core = "0.3"
 lol_html = "1.2"
 pin-project-lite = "0.2"
+thiserror = "1.0"
 tokio = { version = "1.40" }
 tokio-stream = "0.1"
 

--- a/benches/benchmarks/throughput.rs
+++ b/benches/benchmarks/throughput.rs
@@ -7,9 +7,9 @@ use lol_html::html_content::ContentType;
 use tokio::io::AsyncReadExt;
 use tokio::runtime::Runtime;
 use tokio::task;
-use tokio_test::io::Mock;
+use tokio_test::stream_mock::{StreamMock, StreamMockBuilder};
 
-async fn rewrite(source: Mock, settings: Settings<'static, 'static>) {
+async fn rewrite(source: StreamMock<Vec<u8>>, settings: Settings<'static, 'static>) {
     let local_set = task::LocalSet::new();
     local_set.run_until(async move {
         let rewriter = Rewriter::new(source, settings);
@@ -27,8 +27,8 @@ fn bench_throughput(c: &mut Criterion) {
     c.bench_function("end-to-end", move |b| {
         b.to_async(&rt).iter_batched(
             || {
-                let source = tokio_test::io::Builder::new()
-                    .read(b"<h1>Benchmark</h1>")
+                let source = StreamMockBuilder::new()
+                    .next(b"<h1>Benchmark</h1>".into())
                     .build();
                 let mut settings = Settings::new();
                 settings.element_content_handlers = vec![

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -5,39 +5,33 @@ use crate::sink::RelaySink;
 use crate::stream::ByteStream;
 use crate::ByteQueue;
 use atomic_waker::AtomicWaker;
-use futures_core::{ready, Stream};
-use pin_project_lite::pin_project;
+use futures_core::Stream;
 use std::{
     fmt::Debug,
-    future::Future,
-    io,
-    pin::Pin,
     sync::atomic::AtomicBool,
     sync::Arc,
-    task::{Context, Poll},
 };
+use thiserror::Error;
+use tokio_stream::StreamExt;
 
-pin_project! {
-    #[derive(Debug)]
-    pub struct Rewriter<'a, S, I>
-    where
-        S: Stream<Item=I>,
-        I: AsRef<[u8]>,
-    {
-        #[pin] source: S,
-        rewriter: Option<lol_html::HtmlRewriter<'a, RelaySink >>,
-        waker: Arc<AtomicWaker>,
-        done: Arc<AtomicBool>,
-        queue: Arc<ByteQueue>,
-    }
+#[derive(Error, Debug)]
+pub enum RewriterError {
+    #[error("rewriting error: {0}")]
+    RewritingError(#[from] lol_html::errors::RewritingError),
 }
 
-impl<'a, S, I> Rewriter<'a, S, I>
-where
-    S: Stream<Item=I>,
-    I: AsRef<[u8]>,
-{
-    pub fn new(source: S, settings: Settings<'a, '_>) -> Self {
+pub type RewriterResult<T> = Result<T, RewriterError>;
+
+#[derive(Debug)]
+pub struct Rewriter<'a> {
+    rewriter: Option<lol_html::HtmlRewriter<'a, RelaySink>>,
+    waker: Arc<AtomicWaker>,
+    done: Arc<AtomicBool>,
+    queue: Arc<ByteQueue>,
+}
+
+impl<'a> Rewriter<'a> {
+    pub fn new(settings: Settings<'a, '_>) -> Self {
         let waker = Arc::new(AtomicWaker::new());
         let done = Arc::new(AtomicBool::default());
         let queue = Arc::new(ByteQueue::new());
@@ -47,13 +41,11 @@ where
             queue,
             waker,
             done,
-            source,
             rewriter: Some(lol_html::HtmlRewriter::new(settings.into_inner(), sink)),
         }
     }
 
     pub fn with_queue(
-        source: S,
         settings: Settings<'a, '_>,
         queue: Arc<ByteQueue>,
         waker: Arc<AtomicWaker>,
@@ -64,7 +56,6 @@ where
             queue,
             waker,
             done,
-            source,
             rewriter: Some(lol_html::HtmlRewriter::new(settings.into_inner(), sink)),
         }
     }
@@ -77,40 +68,29 @@ where
     pub fn output_stream(&self) -> ByteStream {
         ByteStream::new(self.queue.clone(), self.waker.clone(), self.done.clone())
     }
-}
 
-impl<S, I> Future for Rewriter<'_, S, I>
-where
-    S: Stream<Item=I>,
-    I: AsRef<[u8]>,
-{
-    type Output = io::Result<()>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let mut this = self.project();
-        match this.rewriter {
-            None => {
-                // This should be unreachable, since awaiting this future consumes this object
-                let err = io::Error::new(io::ErrorKind::UnexpectedEof, "Writer has been closed");
-                Poll::Ready(Err(err))
-            }
-            Some(rewriter) => loop {
-                match ready!(this.source.as_mut().poll_next(cx)) {
-                    Some(item) => {
-                        if let Err(err) = rewriter.write(item.as_ref()) {
-                            return Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, err)));
-                        }
-                    }
-                    None => {
-                        // Best effort trying to immediately release rewriter resources
-                        if let Some(rewriter) = this.rewriter.take() {
-                            // We're ignoring failed attempts
-                            let _ = rewriter.end();
-                        }
-                        return Poll::Ready(Ok(()));
-                    }
+    pub async fn rewrite<T, P>(mut self, stream: &mut T) -> RewriterResult<()>
+    where
+        T: Stream<Item=P> + Unpin,
+        P: AsRef<[u8]>,
+    {
+        match &mut self.rewriter {
+            None => unreachable!("The writer should only ever be None when drop has been called"),
+            Some(rewriter) => {
+                while let Some(item) = stream.next().await {
+                    rewriter.write(item.as_ref())?
                 }
             }
+        }
+        Ok(())
+    }
+}
+
+impl<'a> Drop for Rewriter<'a> {
+    fn drop(&mut self) {
+        // Best effort to close the inner rewriter
+        if let Some(rewriter) = self.rewriter.take() {
+            let _ = rewriter.end();
         }
     }
 }
@@ -127,7 +107,7 @@ mod tests {
     #[tokio::test]
     async fn rewrite_html() {
         let expected = "<h1>Succeeded</h1>";
-        let source = StreamMockBuilder::new()
+        let mut source = StreamMockBuilder::new()
             .next(b"<h1>Test</h1>")
             .build();
 
@@ -137,9 +117,10 @@ mod tests {
                 Ok(())
         })];
 
-        let rewriter = Rewriter::new(source, settings);
+        let rewriter = Rewriter::new(settings);
         let mut reader = rewriter.output_reader();
-        rewriter.await.unwrap();
+        let result = rewriter.rewrite(&mut source).await;
+        assert!(result.is_ok(), "Expected rewriting to succeed: {:?}", result);
 
         let mut output = String::new();
         let bytes_read = reader.read_to_string(&mut output).await;

--- a/src/rewriter.rs
+++ b/src/rewriter.rs
@@ -69,10 +69,10 @@ impl<'a> Rewriter<'a> {
         ByteStream::new(self.queue.clone(), self.waker.clone(), self.done.clone())
     }
 
-    pub async fn rewrite<T, P>(mut self, stream: &mut T) -> RewriterResult<()>
+    pub async fn rewrite<S, I>(mut self, stream: &mut S) -> RewriterResult<()>
     where
-        T: Stream<Item=P> + Unpin,
-        P: AsRef<[u8]>,
+        S: Stream<Item=I> + Unpin,
+        I: AsRef<[u8]>,
     {
         match &mut self.rewriter {
             None => unreachable!("The writer should only ever be None when drop has been called"),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -2,7 +2,6 @@ use std::ops::{Deref, DerefMut};
 
 pub struct Settings<'h, 's> {
     settings: lol_html::Settings<'h, 's>,
-    pub buffer_size: usize,
 }
 
 impl<'h, 's> Default for Settings<'h, 's> {
@@ -13,7 +12,7 @@ impl<'h, 's> Default for Settings<'h, 's> {
 
 impl<'h, 's> Settings<'h, 's> {
     pub fn new() -> Self {
-        Self { settings: lol_html::Settings::default(), buffer_size: 4096 }
+        Self { settings: lol_html::Settings::default() }
     }
 
     pub fn into_inner(self) -> lol_html::Settings<'h, 's> {

--- a/src/sink.rs
+++ b/src/sink.rs
@@ -32,6 +32,14 @@ impl OutputSink for RelaySink {
     }
 }
 
+impl Drop for RelaySink {
+    fn drop(&mut self) {
+        self.done.store(true, Ordering::SeqCst);
+        // Inform everybody that's waiting for us that we're done with producing data
+        self.waker.wake();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::RelaySink;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4,6 +4,7 @@ use lol_html::element;
 use lol_html::html_content::ContentType;
 use tokio::io::AsyncReadExt;
 use tokio::task;
+use tokio_test::stream_mock::StreamMockBuilder;
 
 #[tokio::test]
 async fn rewrite_html() {
@@ -14,8 +15,8 @@ async fn rewrite_html() {
             el.replace(expected, ContentType::Html);
             Ok(())
     })];
-    let source = tokio_test::io::Builder::new()
-        .read(b"<h1>Test</h1>")
+    let source = StreamMockBuilder::new()
+        .next(b"<h1>Test</h1>")
         .build();
 
     let local_set = task::LocalSet::new();
@@ -27,7 +28,7 @@ async fn rewrite_html() {
 
         let mut buf = String::new();
         stream.read_to_string(&mut buf).await.unwrap();
-        
+
         let _ = rewriter_handle.await.unwrap();
         buf
     }).await;


### PR DESCRIPTION
Instead of accepting data sources that implement `AsyncRead`, the `Rewriter` now consumes `Stream`s. This lends itself more naturally to the type of data that is transferred by sources that implement `hyper::Body`, which produces data in units of `hyper::body::Frame<Buf>`.